### PR TITLE
Test lowest versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,29 +15,29 @@ cache:
     - $HOME/.composer/cache
  
 env:
-  - SYMFONY_VERSION=2.6.*
+  - SYMFONY_VERSION=2.6.* PACKAGE_VERSION=high
 
 matrix:
   include:
     - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
+      env: SYMFONY_VERSION=2.3.* PACKAGE_VERSION=high
     - php: 5.6
-      env: SYMFONY_VERSION=2.5.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=2.5.* PACKAGE_VERSION=high
+    - php: 5.3.3
+      env: SYMFONY_VERSION=2.3.* PACKAGE_VERSION=low
   allow_failures:
     - php: 5.6
-      env: SYMFONY_VERSION=2.7.*
+      env: SYMFONY_VERSION=2.7.* PACKAGE_VERSION=high
     - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
+      env: SYMFONY_VERSION=3.0.*@dev PACKAGE_VERSION=high
     - php: nightly
 
 before_script:
+  - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
   - composer self-update
-  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
-  - composer require symfony/symfony:${SYMFONY_VERSION} --prefer-dist
+  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
+  - if [[ "$PACKAGE_VERSION" == "high" ]]; then composer update --prefer-source; fi
+  - if [[ "$PACKAGE_VERSION" == "low" ]]; then composer update --prefer-lowest --prefer-source; fi
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script: phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       env: SYMFONY_VERSION=2.3.* PACKAGE_VERSION=high
     - php: 5.6
       env: SYMFONY_VERSION=2.5.* PACKAGE_VERSION=high
-    - php: 5.3.3
+    - php: 5.3
       env: SYMFONY_VERSION=2.3.* PACKAGE_VERSION=low
   allow_failures:
     - php: 5.6

--- a/Admin/Extension/FrontendLinkExtension.php
+++ b/Admin/Extension/FrontendLinkExtension.php
@@ -50,8 +50,16 @@ class FrontendLinkExtension extends AdminExtension
         $this->translator = $translator;
     }
 
+    public function configureSideMenu(
+        AdminInterface $admin,
+        MenuItemInterface $menu,
+        $action,
+        AdminInterface $childAdmin = null
+    ) {
+        $this->configureTabMenu($admin, $menu, $action, $childAdmin);
+    }
+
     /**
-     * @return void
      * @throws InvalidConfigurationException
      */
     public function configureTabMenu(

--- a/Tests/WebTest/RedirectRouteAdminTest.php
+++ b/Tests/WebTest/RedirectRouteAdminTest.php
@@ -84,7 +84,7 @@ class RedirectRouteAdminTest extends BaseTestCase
      */
     private function assertFrontendLinkPresent(Crawler $crawler)
     {
-        $this->assertCount(1, $link = $crawler->filter('a[class="sonata-admin-frontend-link"]'));
+        $this->assertCount(1, $link = $crawler->filter('a[class="sonata-admin-frontend-link"]'), 'The page contains a frontend link');
         $this->assertEquals('/redirect-route-1', $link->attr('href'));
     }
 

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "~1.2,>=1.2.4",
-        "doctrine/phpcr-odm": "~1.1,>=1.1.0-RC1",
+        "symfony-cmf/testing": "dev-lowest_versions",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",
         "symfony/monolog-bundle": "~2.3",
-        "doctrine/orm": "~2.3"
+        "doctrine/orm": "~2.3",
+        "doctrine/data-fixtures": "1.*,>=1.0.0-alpha3"
     },
     "suggest": {
         "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "dev-lowest_versions",
+        "symfony-cmf/testing": "~1.2,>=1.2.6",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
         "symfony-cmf/testing": "~1.2,>=1.2.4",
+        "doctrine/phpcr-odm": "~1.1,>=1.1.0-RC1",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
         "symfony-cmf/testing": "~1.2,>=1.2.3",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*",
+        "matthiasnoback/symfony-dependency-injection-test": "~0.3",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",
         "symfony/monolog-bundle": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "~1.1@stable",
+        "symfony-cmf/testing": "~1.1,>=1.1.0",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "~1.2,>=1.2.3",
+        "symfony-cmf/testing": "~1.2,>=1.2.4",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "~1.1",
+        "symfony-cmf/testing": "~1.1@stable",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "~1.1,>=1.1.0",
+        "symfony-cmf/testing": "~1.2,>=1.2.2",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
-        "symfony-cmf/testing": "~1.2,>=1.2.2",
+        "symfony-cmf/testing": "~1.2,>=1.2.3",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony-cmf/testing": "~1.2,>=1.2.6",
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "0.*",
+        "phpunit/php-code-coverage": "@stable",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",
         "symfony/monolog-bundle": "~2.3",
         "doctrine/orm": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
         "symfony-cmf/testing": "~1.2,>=1.2.3",
-        "matthiasnoback/symfony-dependency-injection-test": "~0.3",
+        "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "0.*",
         "sonata-project/doctrine-phpcr-admin-bundle": "~1.1",
         "symfony/monolog-bundle": "~2.3",


### PR DESCRIPTION
Let's see how this turns out.

I've also removed some unsupported versions and made sure the main tests are against the latest stable versions (sf 2.6 and PHP 5.6)