### PR TITLE
Cache the deps instead of the vendor directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: false
 
 cache:
     directories:
-        - vendor
+        - $HOME/.composer/cache
 
 php:
     - 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   - composer self-update
   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "memory_limit = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi;' 
   - sh -c 'if [ "$SYMFONY_VERSION" != "no" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi;'
-  - composer update --prefer-source
+  - composer update --prefer-dist
   - vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh
 
 script: phpunit --coverage-text


### PR DESCRIPTION
Due to a bug in Composer, caching the vendor directory won't work very nice. (if `master` is aliased as `1.3-dev`, it'll cache the branch name instead of the alias, so it'll install the `master` branch, even if the alias changed to `2.0-dev`).