### PR TITLE
PHPCR test suite references ORM

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
 
         <testsuite name="phpcr">
             <directory>./Tests/Functional</directory>
-            <exclude>./Tests/Functional/Doctrine/Orm</exclude>
+            <exclude>./Tests/Functional/Doctrine/Phpcr</exclude>
         </testsuite>
 
         <testsuite name="orm">


### PR DESCRIPTION
The current `phpunit.xml.dist` PHPCR testsuite loads tests for the ORM.