### PR TITLE
ORM content repository implementation ready

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -118,6 +118,7 @@ class CmfRoutingExtension extends Extension
         if ($config['persistence']['orm']['enabled']) {
             $this->loadOrmProvider($config['persistence']['orm'], $loader, $container, $locales, $config['match_implicit_locale']);
             $hasProvider = true;
+            $hasContentRepository = true;
         }
 
         if (isset($config['route_provider_service_id'])) {
@@ -304,6 +305,10 @@ class CmfRoutingExtension extends Extension
             $definition = $container->getDefinition($this->getAlias() . '.orm_candidates');
             $definition->setArguments(array());
         }
+        $container->setAlias(
+            $this->getAlias() . '.content_repository',
+            $this->getAlias() . '.orm_content_repository'
+        );
     }
 
     /**

--- a/Resources/config/provider-orm.xml
+++ b/Resources/config/provider-orm.xml
@@ -12,7 +12,7 @@
 
     <services>
 
-        <service id="cmf_routing.content_repository" class="%cmf_routing.orm.content_repository.class%">
+        <service id="cmf_routing.orm_content_repository" class="%cmf_routing.orm.content_repository.class%">
             <argument type="service" id="doctrine"/>
             <call method="setManagerName"><argument>%cmf_routing.dynamic.persistence.orm.manager_name%</argument></call>
         </service>


### PR DESCRIPTION
|Q|A|
|---|---|
|Bug fix?|yes
|New feature?|yes
|BC breaks?|no
|Deprecations?|no
|Tests pass?|?
|Fixed tickets|	
|License|MIT
|Doc PR|not yet

ORM content repository implementation was already included in the bundle, 
but not well declared in provider-orm.xml,
nor loaded in the extension.