### PR TITLE
revert BC break introduced in #292

### DIFF
--- a/Admin/RouteAdmin.php
+++ b/Admin/RouteAdmin.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\DoctrinePHPCRAdminBundle\Admin\Admin;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Model\Route;
 use PHPCR\Util\PathHelper;
 
@@ -39,6 +40,13 @@ class RouteAdmin extends Admin
      * @var string
      */
     protected $contentClass;
+
+    /**
+     * @var ControllerResolverInterface
+     *
+     * @deprecated Since 1.4, use the RouteDefaults validator on your document.
+     */
+    protected $controllerResolver;
 
     protected function configureListFields(ListMapper $listMapper)
     {
@@ -107,6 +115,14 @@ class RouteAdmin extends Admin
     public function setContentRoot($contentRoot)
     {
         $this->contentRoot = $contentRoot;
+    }
+
+    /**
+     * @deprecated Since 1.4, use the RouteDefaults validator on your document.
+     */
+    public function setControllerResolver($controllerResolver)
+    {
+        $this->controllerResolver = $controllerResolver;
     }
 
     public function getExportFormats()

--- a/Resources/config/admin-phpcr.xml
+++ b/Resources/config/admin-phpcr.xml
@@ -32,6 +32,10 @@
             <call method="setRouteRoot">
                 <argument>%cmf_routing.dynamic.persistence.phpcr.admin_basepath%</argument>
             </call>
+
+            <call method="setControllerResolver">
+                <argument type="service" id="controller_resolver" />
+            </call>
         </service>
 
         <service id="cmf_routing.redirect_route_admin" class="%cmf_routing.redirect_route_admin.class%">


### PR DESCRIPTION
removing the setControllerResolver method leads to problems when a service definition tries to call this method.
/cc @EmmanuelVella 