### PR TITLE
Generate candidates from decoded URLs

### DIFF
--- a/Doctrine/Phpcr/PrefixCandidates.php
+++ b/Doctrine/Phpcr/PrefixCandidates.php
@@ -103,7 +103,7 @@ class PrefixCandidates extends Candidates
     public function getCandidates(Request $request)
     {
         $candidates = array();
-        $url = $request->getPathInfo();
+        $url = rawurldecode($request->getPathInfo());
         foreach ($this->getPrefixes() as $prefix) {
             $candidates = array_unique(array_merge($candidates, $this->getCandidatesFor($url, $prefix)));
         }

--- a/Tests/Unit/Doctrine/Phpcr/PrefixCandidatesTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/PrefixCandidatesTest.php
@@ -50,6 +50,28 @@ class PrefixCandidatesTest extends CmfUnitTestCase
         );
     }
 
+    public function testGetCandidatesPercentEncoded()
+    {
+        $request = Request::create('/my/path%20percent%20encoded.html');
+
+        $candidates = new PrefixCandidates(array('/routes', '/simple'));
+        $paths = $candidates->getCandidates($request);
+
+        $this->assertEquals(
+            array(
+                '/routes/my/path percent encoded.html',
+                '/routes/my/path percent encoded',
+                '/routes/my',
+                '/routes',
+                '/simple/my/path percent encoded.html',
+                '/simple/my/path percent encoded',
+                '/simple/my',
+                '/simple',
+            ),
+            $paths
+        );
+    }
+
     public function testGetCandidatesLocales()
     {
         $request = Request::create('/de/path.html');


### PR DESCRIPTION
Symfony\Component\Routing\Matcher\UrlMatcher::match() performs a rawurldecode() on a request's pathInfo in order to find matching routes, so one must do the same when generating candidate routes.