### PR TITLE
persisting route condition as well

### DIFF
--- a/Admin/Extension/FrontendLinkExtension.php
+++ b/Admin/Extension/FrontendLinkExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -82,7 +82,7 @@ class FrontendLinkExtension extends AdminExtension
         }
 
         if ($subject instanceof PrefixInterface && !is_string($subject->getId())) {
-            // we have an unpersisted dynamic route 
+            // we have an unpersisted dynamic route
             return;
         }
 

--- a/Admin/Extension/RouteReferrersExtension.php
+++ b/Admin/Extension/RouteReferrersExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Admin/RedirectRouteAdmin.php
+++ b/Admin/RedirectRouteAdmin.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Admin/RouteAdmin.php
+++ b/Admin/RouteAdmin.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/CmfRoutingBundle.php
+++ b/CmfRoutingBundle.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Controller/RedirectController.php
+++ b/Controller/RedirectController.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/Compiler/SetRouterPass.php
+++ b/DependencyInjection/Compiler/SetRouterPass.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/DoctrineProvider.php
+++ b/Doctrine/DoctrineProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Orm/ContentRepository.php
+++ b/Doctrine/Orm/ContentRepository.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Orm/Route.php
+++ b/Doctrine/Orm/Route.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Orm/RouteProvider.php
+++ b/Doctrine/Orm/RouteProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/ContentRepository.php
+++ b/Doctrine/Phpcr/ContentRepository.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/IdPrefixListener.php
+++ b/Doctrine/Phpcr/IdPrefixListener.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/LocaleListener.php
+++ b/Doctrine/Phpcr/LocaleListener.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/PrefixCandidates.php
+++ b/Doctrine/Phpcr/PrefixCandidates.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/PrefixInterface.php
+++ b/Doctrine/Phpcr/PrefixInterface.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/RedirectRoute.php
+++ b/Doctrine/Phpcr/RedirectRoute.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/Route.php
+++ b/Doctrine/Phpcr/Route.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/Phpcr/RouteProvider.php
+++ b/Doctrine/Phpcr/RouteProvider.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Doctrine/RouteConditionMetadataListener.php
+++ b/Doctrine/RouteConditionMetadataListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2015 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\RoutingBundle\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata as OrmClassMetadata;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata as PhpcrClassMetadata;
+
+/**
+ * Metadata listener to remove mapping for condition field if the field does not exist.
+ *
+ * The condition option was only added in Symfony 2.4 and is missing from 2.3.
+ * When we drop Symfony 2.3 support, this listener can be dropped.
+ *
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+class RouteConditionMetadataListener implements EventSubscriber
+{
+    /**
+     * @return array
+     */
+    public function getSubscribedEvents()
+    {
+        return array(
+            'loadClassMetadata',
+        );
+    }
+
+    /**
+     * Handle the load class metadata event: remove translated attribute from
+     * fields and remove the locale mapping if present.
+     *
+     * @param LoadClassMetadataEventArgs $eventArgs
+     */
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        if (!property_exists('Symfony\Component\Routing\Route', 'condition')) {
+            return; // nothing to do
+        }
+
+        $meta = $eventArgs->getClassMetadata();
+        if ($meta->getReflectionClass()->getName() !== 'Symfony\Component\Routing\Route') {
+            return;
+        }
+
+        if ($meta instanceof OrmClassMetadata) {
+            /** @var $meta OrmClassMetadata */
+            $meta->mapField(array(
+                'fieldName' => 'condition',
+                'type' => 'string',
+                'nullable' => true,
+            ));
+        } elseif ($meta instanceof PhpcrClassMetadata) {
+            /** @var $meta PhpcrClassMetadata */
+            $meta->mapField(array(
+                'fieldName' => 'condition',
+                'type' => 'string',
+                'nullable' => true,
+            ));
+        } else {
+            throw new \LogicException(sprintf('Class metadata was neither PHPCR nor ORM but %s', get_class($meta)));
+        }
+    }
+}

--- a/Form/Type/RouteTypeType.php
+++ b/Form/Type/RouteTypeType.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Model/RedirectRoute.php
+++ b/Model/RedirectRoute.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Model/Route.php
+++ b/Model/Route.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Resources/config/routing-dynamic.xml
+++ b/Resources/config/routing-dynamic.xml
@@ -98,5 +98,10 @@
             <argument type="service" id="router" />
         </service>
 
+        <service id="cmf_routing.persistence.doctrine.route_condition_metadata_listener" class="Symfony\Cmf\Bundle\RoutingBundle\Doctrine\RouteConditionMetadataListener">
+            <tag name="doctrine.event_subscriber"/>
+            <tag name="doctrine_phpcr.event_subscriber"/>
+        </service>
+
     </services>
 </container>

--- a/Resources/meta/LICENSE
+++ b/Resources/meta/LICENSE
@@ -2,7 +2,7 @@ RoutingBundle
 
 The MIT License
 
-Copyright (c) 2011-2014 Symfony2 CMF
+Copyright (c) 2011-2015 Symfony2 CMF
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Routing/DynamicRouter.php
+++ b/Routing/DynamicRouter.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/BaseTestCase.php
+++ b/Tests/Functional/BaseTestCase.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/Controller/RedirectControllerTest.php
+++ b/Tests/Functional/Controller/RedirectControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/Doctrine/Orm/OrmTestCase.php
+++ b/Tests/Functional/Doctrine/Orm/OrmTestCase.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/Doctrine/Orm/RouteProviderTest.php
+++ b/Tests/Functional/Doctrine/Orm/RouteProviderTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/Doctrine/Phpcr/RedirectRouteTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/RedirectRouteTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Functional/Doctrine/Phpcr/RouteTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/RouteTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -88,6 +88,27 @@ class RouteTest extends BaseTestCase
         $this->assertTrue(1 >= count($options)); // there is a default option for the compiler
 
         return $route;
+    }
+
+    public function testConditionOption()
+    {
+        if (!property_exists('Symfony\Component\Routing\Route', 'condition')) {
+            $this->markTestSkipped('This version of symfony does not have the condition property on the Route.');
+        }
+
+        $route = new Route();
+        $root = $this->getDm()->find(null, self::ROUTE_ROOT);
+
+        $route->setPosition($root, 'conditionroute');
+        $route->setCondition('foobar');
+
+        $this->getDm()->persist($route);
+        $this->getDm()->flush();
+        $this->getDm()->clear();
+
+        $route = $this->getDm()->find(null, self::ROUTE_ROOT.'/conditionroute');
+
+        $this->assertEquals('foobar', $route->getCondition());
     }
 
     public function testRootRoute()

--- a/Tests/Functional/Routing/DynamicRouterTest.php
+++ b/Tests/Functional/Routing/DynamicRouterTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Resources/DataFixtures/Phpcr/LoadRouteData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadRouteData.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Resources/Document/Content.php
+++ b/Tests/Resources/Document/Content.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Controller/RedirectControllerTest.php
+++ b/Tests/Unit/Controller/RedirectControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/DependencyInjection/Compiler/SetRouterPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/SetRouterPassTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/DependencyInjection/XmlSchemaTest.php
+++ b/Tests/Unit/DependencyInjection/XmlSchemaTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Orm/ContentRepositoryTest.php
+++ b/Tests/Unit/Doctrine/Orm/ContentRepositoryTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Orm/RouteProviderTest.php
+++ b/Tests/Unit/Doctrine/Orm/RouteProviderTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Phpcr/ContentRepositoryTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/ContentRepositoryTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Phpcr/IdPrefixListenerTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/IdPrefixListenerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Phpcr/LocaleListenerTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/LocaleListenerTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Phpcr/RouteProviderTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/RouteProviderTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Doctrine/Phpcr/RouteTest.php
+++ b/Tests/Unit/Doctrine/Phpcr/RouteTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Form/Type/RouteTypeTypeTest.php
+++ b/Tests/Unit/Form/Type/RouteTypeTypeTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Routing/DynamicRouterTest.php
+++ b/Tests/Unit/Routing/DynamicRouterTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/Unit/Validator/Constraints/RouteDefaultsValidatorTest.php
+++ b/Tests/Unit/Validator/Constraints/RouteDefaultsValidatorTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Tests/WebTest/RedirectRouteAdminTest.php
+++ b/Tests/WebTest/RedirectRouteAdminTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -90,7 +90,7 @@ class RedirectRouteAdminTest extends BaseTestCase
     {
         $this->assertCount(0, $crawler->filter('a[class="sonata-admin-frontend-link"]'));
     }
-    
+
     private function assertResponseOk(Response $response)
     {
         $this->assertEquals(200, $response->getStatusCode(), $response->getContent());

--- a/Tests/WebTest/RouteAdminTest.php
+++ b/Tests/WebTest/RouteAdminTest.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -90,7 +90,7 @@ class RouteAdminTest extends BaseTestCase
     {
         $this->assertCount(0, $crawler->filter('a[class="sonata-admin-frontend-link"]'));
     }
-    
+
     private function assertResponseOk(Response $response)
     {
         $this->assertEquals(200, $response->getStatusCode(), $response->getContent());

--- a/Validator/Constraints/RouteDefaults.php
+++ b/Validator/Constraints/RouteDefaults.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/Validator/Constraints/RouteDefaultsValidator.php
+++ b/Validator/Constraints/RouteDefaultsValidator.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the Symfony CMF package.
  *
- * (c) 2011-2014 Symfony CMF
+ * (c) 2011-2015 Symfony CMF
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
fix #270

adding a metadata listener to keep symfony 2.3 support for now. this listener can be removed again when we drop symfony 2.7 support.