### PR TITLE
Fix route basepaths configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* **2015-10-28**: Deprecated `cmf_routing.dynamic.persistence.phpcr.route_basepath`
+  setting and parameter in favor of `cmf_routing.dynamic.persistence.phpcr.route_basepaths`.
+  The old names will be kept for BC reasons and removed in 2.0.
+
 1.3.0-RC1
 ---------
 

--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -240,13 +240,15 @@ class CmfRoutingExtension extends Extension
 
         $container->setParameter(
             $this->getAlias() . '.dynamic.persistence.phpcr.route_basepaths',
-            $config['route_basepaths']
+            array_values(array_unique($config['route_basepaths']))
         );
 
-        $basePath = reset($config['route_basepaths']);
+        /**
+         * @deprecated The cmf_routing.dynamic.persistence.phpcr.route_basepath parameter is deprecated as of version 1.4 and will be removed in 2.0. Use the cmf_routing.dynamic.persistence.phpcr.route_basepaths parameter instead.
+         */
         $container->setParameter(
             $this->getAlias() . '.dynamic.persistence.phpcr.route_basepath',
-            $basePath
+            reset($config['route_basepaths'])
         );
 
         $container->setParameter(
@@ -288,7 +290,7 @@ class CmfRoutingExtension extends Extension
             return;
         }
 
-        $basePath = empty($config['admin_basepath']) ? reset($config['route_basepaths']) : $config['admin_basepath'];
+        $basePath = $config['admin_basepath'] ?: reset($config['route_basepaths']);
         $container->setParameter($this->getAlias() . '.dynamic.persistence.phpcr.admin_basepath', $basePath);
 
         $loader->load('admin-phpcr.xml');

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -81,13 +81,25 @@ class Configuration implements ConfigurationInterface
                                         ->ifTrue(function ($v) { isset($v['route_basepath']) && isset($v['route_basepaths']); })
                                         ->thenInvalid('Found values for both "route_basepath" and "route_basepaths", use "route_basepaths" instead.')
                                     ->end()
+                                    ->beforeNormalization()
+                                        ->ifTrue(function ($v) { return isset($v['route_basepath']); })
+                                        ->then(function ($v) {
+                                            @trigger_error('The route_basepath setting is deprecated as of version 1.4 and will be removed in 2.0. Use route_basepaths instead.', E_USER_DEPRECATED);
+
+                                            return $v;
+                                        })
+                                    ->end()
                                     ->children()
                                         ->scalarNode('manager_name')->defaultNull()->end()
                                         ->arrayNode('route_basepaths')
+                                            ->beforeNormalization()
+                                                ->ifString()
+                                                ->then(function ($v) { return array($v); })
+                                            ->end()
                                             ->prototype('scalar')->end()
                                             ->defaultValue(array('/cms/routes'))
                                         ->end()
-                                        ->scalarNode('admin_basepath')->end()
+                                        ->scalarNode('admin_basepath')->defaultNull()->end()
                                         ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                                         ->enumNode('use_sonata_admin')
                                             ->beforeNormalization()

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -57,6 +57,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                             '/simple',
                         ),
                         'content_basepath' => '/cms/content',
+                        'admin_basepath' => null,
                         'manager_name' => null,
                         'use_sonata_admin' => false,
                         'enable_initializer' => true,

--- a/UPGRADE-1.3.md
+++ b/UPGRADE-1.3.md
@@ -1,0 +1,55 @@
+UPGRADE FROM 1.2 TO 1.3
+=======================
+
+Configuration
+-------------
+
+ * Renamed the `cmf_routing.dynamic.persistence.phpcr.route_basepath` setting
+   to `route_basepaths`.
+
+   **Before**
+   ```yaml
+   cmf_routing:
+       dynamic:
+           persistence:
+               phpcr:
+                   route_basepath: /cms/custom
+   ```
+
+   ```xml
+   <config xmlns="http://cmf.symfony.com/schema/dic/routing">
+       <dynamic>
+           <persistence>
+               <phpcr route-basepath="/cms/custom" />
+           </persistence>
+       </dynamic>
+   </config>
+    ```
+
+   **After**
+   ```yaml
+   cmf_routing:
+       dynamic:
+           persistence:
+               phpcr:
+                   route_basepaths: /cms/custom
+   ```
+
+   ```xml
+   <config xmlns="http://cmf.symfony.com/schema/dic/routing">
+       <dynamic>
+           <persistence>
+               <phpcr>
+                   <route-basepath>/cms/custom</route-basepath>
+               </phpcr>
+           </persistence>
+       </dynamic>
+   </config>
+    ```
+
+DependencyInjection
+-------------------
+
+ * Renamed the `cmf_routing.dynamic.persistence.phpcr.route_basepath` parameter
+   to `cmf_routing.dynamic.persistence.phpcr.route_basepaths` and changed its
+   type to an array.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | https://github.com/symfony-cmf/RoutingBundle/issues/290
| License       | MIT
| Doc PR        | https://github.com/symfony-cmf/symfony-cmf-docs/pull/715

* Deprecated the `route_basepath` setting in favor of `route_basepaths`
* Allowed string values for `route_basepaths`, in case only one basepath needs to be configured
* Configuring `route_basepaths` overrides the default `/cms/routes` value, add it explicitely to include it in the basepath list
* Multiple `route_basepaths` configuration in multiple config files results in merging all configured basepaths.
* Make sure no duplicated basepaths are configured
* Improve testing

/cc @dbu