### PR TITLE
Clean up DI Extension & Configuration classes

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -227,12 +227,12 @@ class CmfRoutingExtension extends Extension
 
     private function loadSonataPhpcrAdmin($config, XmlFileLoader $loader, ContainerBuilder $container)
     {
-        $loader->load('admin-phpcr.xml');
-
         $bundles = $container->getParameter('kernel.bundles');
         if ('auto' === $config['use_sonata_admin'] && !isset($bundles['SonataDoctrinePHPCRAdminBundle'])) {
             return;
         }
+
+        $loader->load('admin-phpcr.xml');
 
         $basePath = $config['admin_basepath'] ?: reset($config['route_basepaths']);
         $container->setParameter('cmf_routing.dynamic.persistence.phpcr.admin_basepath', $basePath);

--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -22,6 +22,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 /**
  * @author Philippo de Santis
  * @author David Buchmann
+ * @author Wouter de Jong <wouter@wouterj.nl>
  */
 class CmfRoutingExtension extends Extension
 {
@@ -33,32 +34,35 @@ class CmfRoutingExtension extends Extension
         $config = $this->processConfiguration(new Configuration(), $configs);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        if ($config['dynamic']['enabled']) {
-            // load this even if no explicit enabled value but some configuration
+        if ($this->isConfigEnabled($container, $config['dynamic'])) {
             $this->setupDynamicRouter($config['dynamic'], $container, $loader);
         }
 
-        /* set up the chain router */
-        $loader->load('routing-chain.xml');
-        $container->setParameter($this->getAlias() . '.replace_symfony_router', $config['chain']['replace_symfony_router']);
-
-        // add the routers defined in the configuration mapping
-        $router = $container->getDefinition($this->getAlias() . '.router');
-        foreach ($config['chain']['routers_by_id'] as $id => $priority) {
-            $router->addMethodCall('add', array(new Reference($id), trim($priority)));
-        }
-
+        $this->setupChainRouter($config, $container, $loader);
         $this->setupFormTypes($config, $container, $loader);
 
         $loader->load('validators.xml');
     }
 
-    public function setupFormTypes(array $config, ContainerBuilder $container, LoaderInterface $loader)
+    private function setupChainRouter(array $config, ContainerBuilder $container, LoaderInterface $loader)
+    {
+        $loader->load('routing-chain.xml');
+
+        $container->setParameter('cmf_routing.replace_symfony_router', $config['chain']['replace_symfony_router']);
+
+        // add the routers defined in the configuration mapping
+        $router = $container->getDefinition('cmf_routing.router');
+        foreach ($config['chain']['routers_by_id'] as $id => $priority) {
+            $router->addMethodCall('add', array(new Reference($id), trim($priority)));
+        }
+    }
+
+    private function setupFormTypes(array $config, ContainerBuilder $container, LoaderInterface $loader)
     {
         $loader->load('form-type.xml');
 
         if (isset($config['dynamic'])) {
-            $routeTypeTypeDefinition = $container->getDefinition($this->getAlias() . '.route_type_form_type');
+            $routeTypeTypeDefinition = $container->getDefinition('cmf_routing.route_type_form_type');
 
             foreach (array_keys($config['dynamic']['controllers_by_type']) as $routeType) {
                 $routeTypeTypeDefinition->addMethodCall('addRouteType', array($routeType));
@@ -75,102 +79,81 @@ class CmfRoutingExtension extends Extension
      */
     private function setupDynamicRouter(array $config, ContainerBuilder $container, LoaderInterface $loader)
     {
+        $loader->load('routing-dynamic.xml');
+
         // strip whitespace (XML support)
         foreach (array('controllers_by_type', 'controllers_by_class', 'templates_by_class', 'route_filters_by_id') as $option) {
-            $config[$option] = array_map(function ($value) {
-                return trim($value);
-            }, $config[$option]);
+            $config[$option] = array_map('trim', $config[$option]);
         }
 
         $defaultController = $config['default_controller'];
         if (null === $defaultController) {
             $defaultController = $config['generic_controller'];
         }
-        $container->setParameter($this->getAlias() . '.default_controller', $defaultController);
-        $container->setParameter($this->getAlias() . '.generic_controller', $config['generic_controller']);
-        $container->setParameter($this->getAlias() . '.controllers_by_type', $config['controllers_by_type']);
-        $container->setParameter($this->getAlias() . '.controllers_by_class', $config['controllers_by_class']);
-        $container->setParameter($this->getAlias() . '.templates_by_class', $config['templates_by_class']);
-        $container->setParameter($this->getAlias() . '.uri_filter_regexp', $config['uri_filter_regexp']);
-        $container->setParameter($this->getAlias() . '.route_collection_limit', $config['route_collection_limit']);
+        $container->setParameter('cmf_routing.default_controller', $defaultController);
 
-        $locales = empty($config['locales']) ? array() : $config['locales'];
-        $container->setParameter($this->getAlias() . '.dynamic.locales', $locales);
-        if (count($locales) === 0 && $config['auto_locale_pattern']) {
+        $locales = $config['locales'];
+        if (0 === count($locales) && $config['auto_locale_pattern']) {
             throw new InvalidConfigurationException('It makes no sense to activate auto_locale_pattern when no locales are configured.');
         }
-        $container->setParameter($this->getAlias() . '.dynamic.auto_locale_pattern', $config['auto_locale_pattern']);
 
-        $container->setParameter($this->getAlias() . '.dynamic.limit_candidates', $config['limit_candidates']);
-
-        $loader->load('routing-dynamic.xml');
+        $this->configureParameters($container, $config, array(
+            'generic_controller' => 'generic_controller',
+            'controllers_by_type' => 'controllers_by_type',
+            'controllers_by_class' => 'controllers_by_class',
+            'templates_by_class' => 'templates_by_class',
+            'uri_filter_regexp' => 'uri_filter_regexp',
+            'route_collection_limit' => 'route_collection_limit',
+            'limit_candidates' => 'dynamic.limit_candidates',
+            'locales' => 'dynamic.locales',
+            'auto_locale_pattern' => 'dynamic.auto_locale_pattern',
+        ));
 
         $hasProvider = false;
         $hasContentRepository = false;
-        if ($config['persistence']['phpcr']['enabled'] && $config['persistence']['orm']['enabled']) {
-            throw new InvalidConfigurationException('You can only enable either phpcr or orm, not both.');
-        }
-
         if ($config['persistence']['phpcr']['enabled']) {
             $this->loadPhpcrProvider($config['persistence']['phpcr'], $loader, $container, $locales, $config['match_implicit_locale']);
-            $hasProvider = true;
-            $hasContentRepository = true;
+            $hasProvider = $hasContentRepository = true;
         }
 
         if ($config['persistence']['orm']['enabled']) {
             $this->loadOrmProvider($config['persistence']['orm'], $loader, $container, $locales, $config['match_implicit_locale']);
-            $hasProvider = true;
-            $hasContentRepository = true;
+            $hasProvider = $hasContentRepository = true;
         }
 
         if (isset($config['route_provider_service_id'])) {
-            $container->setAlias($this->getAlias() . '.route_provider', $config['route_provider_service_id']);
+            $container->setAlias('cmf_routing.route_provider', $config['route_provider_service_id']);
             $hasProvider = true;
         }
+
         if (!$hasProvider) {
             throw new InvalidConfigurationException('When the dynamic router is enabled, you need to either enable one of the persistence layers or set the cmf_routing.dynamic.route_provider_service_id option');
         }
+
         if (isset($config['content_repository_service_id'])) {
-            $container->setAlias($this->getAlias() . '.content_repository', $config['content_repository_service_id']);
+            $container->setAlias('cmf_routing.content_repository', $config['content_repository_service_id']);
             $hasContentRepository = true;
         }
+
         // content repository is optional
         if ($hasContentRepository) {
-            $generator = $container->getDefinition($this->getAlias() . '.generator');
-            $generator->addMethodCall('setContentRepository', array(
-                new Reference($this->getAlias() . '.content_repository'),
-            ));
+            $generator = $container->getDefinition('cmf_routing.generator');
+            $generator->addMethodCall('setContentRepository', array(new Reference('cmf_routing.content_repository')));
         }
 
-        $dynamic = $container->getDefinition($this->getAlias() . '.dynamic_router');
+        $dynamic = $container->getDefinition('cmf_routing.dynamic_router');
 
         // if any mappings are defined, set the respective route enhancer
-        if (!empty($config['controllers_by_type'])) {
-            $dynamic->addMethodCall(
-                'addRouteEnhancer',
-                array(
-                    new Reference($this->getAlias() . '.enhancer.controllers_by_type'),
-                    60
-                )
-            );
+        if (count($config['controllers_by_type']) > 0) {
+            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.controllers_by_type'), 60));
         }
-        if (!empty($config['controllers_by_class'])) {
-            $dynamic->addMethodCall(
-                'addRouteEnhancer',
-                array(
-                    new Reference($this->getAlias() . '.enhancer.controllers_by_class'),
-                    50
-                )
-            );
+
+        if (count($config['controllers_by_class']) > 0) {
+            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.controllers_by_class'), 50));
         }
-        if (!empty($config['templates_by_class'])) {
-            $dynamic->addMethodCall(
-                'addRouteEnhancer',
-                array(
-                    new Reference($this->getAlias() . '.enhancer.templates_by_class'),
-                    40
-                )
-            );
+
+        if (count($config['templates_by_class']) > 0) {
+            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.templates_by_class'), 40));
 
             /*
              * The CoreBundle prepends the controller from ContentBundle if the
@@ -184,46 +167,29 @@ class CmfRoutingExtension extends Extension
                 throw new InvalidConfigurationException('If you want to configure templates_by_class, you need to configure the generic_controller option.');
             }
 
-            if (is_string($config['generic_controller'])) {
-                // if the content class defines the template, we also need to make sure we use the generic controller for those routes
-                $controllerForTemplates = array();
-                foreach ($config['templates_by_class'] as $key => $value) {
-                    $controllerForTemplates[$key] = $config['generic_controller'];
-                }
-
-                $definition = $container->getDefinition($this->getAlias() . '.enhancer.controller_for_templates_by_class');
-                $definition->replaceArgument(2, $controllerForTemplates);
-
-                $dynamic->addMethodCall(
-                    'addRouteEnhancer',
-                    array(
-                        new Reference($this->getAlias() . '.enhancer.controller_for_templates_by_class'),
-                        30
-                    )
-                );
+            // if the content class defines the template, we also need to make sure we use the generic controller for those routes
+            $controllerForTemplates = array();
+            foreach ($config['templates_by_class'] as $key => $value) {
+                $controllerForTemplates[$key] = $config['generic_controller'];
             }
-        }
-        if (!empty($config['generic_controller']) && $config['generic_controller'] !== $defaultController) {
-            $dynamic->addMethodCall(
-                'addRouteEnhancer',
-                array(
-                    new Reference($this->getAlias() . '.enhancer.explicit_template'),
-                    10
-                )
-            );
-        }
-        if ($defaultController) {
-            $dynamic->addMethodCall(
-                'addRouteEnhancer',
-                array(
-                    new Reference($this->getAlias() . '.enhancer.default_controller'),
-                    -100
-                )
-            );
+
+            $definition = $container->getDefinition('cmf_routing.enhancer.controller_for_templates_by_class');
+            $definition->replaceArgument(2, $controllerForTemplates);
+
+            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.controller_for_templates_by_class'), 30));
         }
 
-        if (!empty($config['route_filters_by_id'])) {
-            $matcher = $container->getDefinition($this->getAlias() . '.nested_matcher');
+        if (null !== $config['generic_controller'] && $defaultController !== $config['generic_controller']) {
+            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.explicit_template'), 10));
+        }
+
+        if (null !== $defaultController) {
+            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.default_controller'), -100));
+        }
+
+        if (count($config['route_filters_by_id']) > 0) {
+            $matcher = $container->getDefinition('cmf_routing.nested_matcher');
+
             foreach ($config['route_filters_by_id'] as $id => $priority) {
                 $matcher->addMethodCall('addRouteFilter', array(new Reference($id), $priority));
             }
@@ -232,49 +198,25 @@ class CmfRoutingExtension extends Extension
         $dynamic->replaceArgument(2, new Reference($config['url_generator']));
     }
 
-    public function loadPhpcrProvider($config, XmlFileLoader $loader, ContainerBuilder $container, $locales, $matchImplicitLocale)
+    private function loadPhpcrProvider($config, XmlFileLoader $loader, ContainerBuilder $container, array $locales, $matchImplicitLocale)
     {
         $loader->load('provider-phpcr.xml');
 
-        $container->setParameter($this->getAlias() . '.backend_type_phpcr', true);
-
-        $container->setParameter(
-            $this->getAlias() . '.dynamic.persistence.phpcr.route_basepaths',
-            array_values(array_unique($config['route_basepaths']))
-        );
+        $container->setParameter('cmf_routing.backend_type_phpcr', true);
+        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.route_basepaths', array_values(array_unique($config['route_basepaths'])));
 
         /**
          * @deprecated The cmf_routing.dynamic.persistence.phpcr.route_basepath parameter is deprecated as of version 1.4 and will be removed in 2.0. Use the cmf_routing.dynamic.persistence.phpcr.route_basepaths parameter instead.
          */
-        $container->setParameter(
-            $this->getAlias() . '.dynamic.persistence.phpcr.route_basepath',
-            reset($config['route_basepaths'])
-        );
+        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.route_basepath', reset($config['route_basepaths']));
+        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.content_basepath', $config['content_basepath']);
+        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.manager_name', $config['manager_name']);
 
-        $container->setParameter(
-            $this->getAlias() . '.dynamic.persistence.phpcr.content_basepath',
-            $config['content_basepath']
-        );
-
-        $container->setParameter(
-            $this->getAlias() . '.dynamic.persistence.phpcr.manager_name',
-            $config['manager_name']
-        );
-
-        $container->setAlias(
-            $this->getAlias() . '.route_provider',
-            $this->getAlias() . '.phpcr_route_provider'
-        );
-        $container->setAlias(
-            $this->getAlias() . '.content_repository',
-            $this->getAlias() . '.phpcr_content_repository'
-        );
-
-        if (!$locales) {
-            $container->removeDefinition($this->getAlias() . '.phpcrodm_route_locale_listener');
+        if (0 === count($locales)) {
+            $container->removeDefinition('cmf_routing.phpcrodm_route_locale_listener');
         } elseif (!$matchImplicitLocale) {
             // remove all but the prefixes configuration from the service definition.
-            $definition = $container->getDefinition($this->getAlias() . '.phpcr_candidates_prefix');
+            $definition = $container->getDefinition('cmf_routing.phpcr_candidates_prefix');
             $definition->setArguments(array($definition->getArgument(0)));
         }
 
@@ -283,38 +225,46 @@ class CmfRoutingExtension extends Extension
         }
     }
 
-    public function loadSonataPhpcrAdmin($config, XmlFileLoader $loader, ContainerBuilder $container)
+    private function loadSonataPhpcrAdmin($config, XmlFileLoader $loader, ContainerBuilder $container)
     {
+        $loader->load('admin-phpcr.xml');
+
         $bundles = $container->getParameter('kernel.bundles');
         if ('auto' === $config['use_sonata_admin'] && !isset($bundles['SonataDoctrinePHPCRAdminBundle'])) {
             return;
         }
 
         $basePath = $config['admin_basepath'] ?: reset($config['route_basepaths']);
-        $container->setParameter($this->getAlias() . '.dynamic.persistence.phpcr.admin_basepath', $basePath);
-
-        $loader->load('admin-phpcr.xml');
+        $container->setParameter('cmf_routing.dynamic.persistence.phpcr.admin_basepath', $basePath);
 
         if ($config['enable_initializer']) {
             $loader->load('initializer-phpcr.xml');
         }
     }
 
-    public function loadOrmProvider($config, XmlFileLoader $loader, ContainerBuilder $container, $matchImplicitLocale)
+    private function loadOrmProvider($config, XmlFileLoader $loader, ContainerBuilder $container, $matchImplicitLocale)
     {
-        $container->setParameter($this->getAlias() . '.dynamic.persistence.orm.manager_name', $config['manager_name']);
-        $container->setParameter($this->getAlias() . '.backend_type_orm', true);
         $loader->load('provider-orm.xml');
+
+        $container->setParameter('cmf_routing.backend_type_orm', true);
+        $container->setParameter('cmf_routing.dynamic.persistence.orm.manager_name', $config['manager_name']);
 
         if (!$matchImplicitLocale) {
             // remove the locales argument from the candidates
-            $definition = $container->getDefinition($this->getAlias() . '.orm_candidates');
-            $definition->setArguments(array());
+            $container->getDefinition('cmf_routing.orm_candidates')->setArguments(array());
         }
-        $container->setAlias(
-            $this->getAlias() . '.content_repository',
-            $this->getAlias() . '.orm_content_repository'
-        );
+    }
+
+    /**
+     * @param ContainerBuilder $container          The container builder
+     * @param array            $config             The config array
+     * @param array            $settingToParameter An array with setting to parameter mappings (key = setting, value = parameter name without alias prefix)
+     */
+    private function configureParameters(ContainerBuilder $container, array $config, array $settingToParameter)
+    {
+        foreach ($settingToParameter as $setting => $parameter) {
+            $container->setParameter('cmf_routing.'.$parameter, $config[$setting]);
+        }
     }
 
     /**

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -105,7 +105,7 @@ class Configuration implements ConfigurationInterface
                                         ->thenInvalid('Found values for both "route_basepath" and "route_basepaths", use "route_basepaths" instead.')
                                     ->end()
                                     ->beforeNormalization()
-                                        ->ifTrue(function ($v) { return isset($v['route_basepath']); })
+                                        ->ifTrue(function ($v) { return isset($v['route_basepath']) && !is_array($v['route_basepath']); })
                                         ->then(function ($v) {
                                             @trigger_error('The route_basepath setting is deprecated as of version 1.4 and will be removed in 2.0. Use route_basepaths instead.', E_USER_DEPRECATED);
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Cmf\Bundle\RoutingBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
@@ -32,7 +33,17 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('cmf_routing')
+        $root = $treeBuilder->root('cmf_routing');
+
+        $this->addChainSection($root);
+        $this->addDynamicSection($root);
+
+        return $treeBuilder;
+    }
+
+    private function addChainSection(ArrayNodeDefinition $root)
+    {
+        $root
             ->children()
                 ->arrayNode('chain')
                     ->addDefaultsIfNotSet()
@@ -42,10 +53,18 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue(array('router.default' => 100))
                             ->useAttributeAsKey('id')
                             ->prototype('scalar')->end()
-                        ->end()
+                        ->end() // routers_by_id
                         ->booleanNode('replace_symfony_router')->defaultTrue()->end()
                     ->end()
-                ->end()
+                ->end()// chain
+            ->end()
+        ;
+    }
+
+    private function addDynamicSection(ArrayNodeDefinition $root)
+    {
+        $root
+            ->children()
                 ->arrayNode('dynamic')
                     ->fixXmlConfig('controller_by_type', 'controllers_by_type')
                     ->fixXmlConfig('controller_by_class', 'controllers_by_class')
@@ -61,17 +80,21 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('controllers_by_type')
                             ->useAttributeAsKey('type')
                             ->prototype('scalar')->end()
-                        ->end()
+                        ->end() // controllers_by_type
                         ->arrayNode('controllers_by_class')
                             ->useAttributeAsKey('class')
                             ->prototype('scalar')->end()
-                        ->end()
+                        ->end() // controllers_by_class
                         ->arrayNode('templates_by_class')
                             ->useAttributeAsKey('class')
                             ->prototype('scalar')->end()
-                        ->end()
+                        ->end() // templates_by_class
                         ->arrayNode('persistence')
                             ->addDefaultsIfNotSet()
+                            ->validate()
+                                ->ifTrue(function ($v) { return count(array_filter($v, function ($persistence) { return $persistence['enabled']; })) > 1; })
+                                ->thenInvalid('Only one persistence layer can be enabled at the same time.')
+                            ->end()
                             ->children()
                                 ->arrayNode('phpcr')
                                     ->addDefaultsIfNotSet()
@@ -98,7 +121,7 @@ class Configuration implements ConfigurationInterface
                                             ->end()
                                             ->prototype('scalar')->end()
                                             ->defaultValue(array('/cms/routes'))
-                                        ->end()
+                                        ->end() // route_basepaths
                                         ->scalarNode('admin_basepath')->defaultNull()->end()
                                         ->scalarNode('content_basepath')->defaultValue('/cms/content')->end()
                                         ->enumNode('use_sonata_admin')
@@ -119,42 +142,41 @@ class Configuration implements ConfigurationInterface
                                             ->end()
                                             ->values(array(true, false, 'auto'))
                                             ->defaultValue('auto')
-                                        ->end()
+                                        ->end() // use_sonata_admin
                                         ->booleanNode('enable_initializer')->defaultTrue()->end()
                                     ->end()
-                                ->end()
+                                ->end() // phpcr
                                 ->arrayNode('orm')
                                     ->addDefaultsIfNotSet()
                                     ->canBeEnabled()
                                     ->children()
                                         ->scalarNode('manager_name')->defaultNull()->end()
                                     ->end()
-                                ->end()
+                                ->end() // orm
                             ->end()
-                        ->end()
+                        ->end() // persistence
                         ->scalarNode('uri_filter_regexp')->defaultValue('')->end()
                         ->scalarNode('route_provider_service_id')->end()
                         ->arrayNode('route_filters_by_id')
                             ->canBeUnset()
+                            ->defaultValue(array())
                             ->useAttributeAsKey('id')
                             ->prototype('scalar')->end()
-                        ->end()
+                        ->end() // route_filters_by_id
                         ->scalarNode('content_repository_service_id')->end()
                         ->arrayNode('locales')
                             ->prototype('scalar')->end()
-                        ->end()
+                        ->end() // locales
                         ->integerNode('limit_candidates')->defaultValue(20)->end()
                         ->booleanNode('match_implicit_locale')->defaultValue(true)->end()
                         ->booleanNode('auto_locale_pattern')->defaultValue(false)->end()
                         ->scalarNode('url_generator')
                             ->defaultValue('cmf_routing.generator')
                             ->info('URL generator service ID')
-                        ->end()
+                        ->end() // url_generator
                     ->end()
-                ->end()
+                ->end() // dynamic
             ->end()
         ;
-
-        return $treeBuilder;
     }
 }

--- a/Resources/config/provider-orm.xml
+++ b/Resources/config/provider-orm.xml
@@ -17,6 +17,8 @@
             <call method="setManagerName"><argument>%cmf_routing.dynamic.persistence.orm.manager_name%</argument></call>
         </service>
 
+        <service id="cmf_routing.content_repository" alias="cmf_routing.orm_content_repository"/>
+
         <service id="cmf_routing.orm_candidates" class="%cmf_routing.orm_candidates.class%">
             <argument>%cmf_routing.dynamic.locales%</argument>
             <argument>%cmf_routing.dynamic.limit_candidates%</argument>

--- a/Resources/config/provider-phpcr.xml
+++ b/Resources/config/provider-phpcr.xml
@@ -22,6 +22,8 @@
             <call method="setRouteCollectionLimit"><argument>%cmf_routing.route_collection_limit%</argument></call>
         </service>
 
+        <service id="cmf_routing.route_provider" alias="cmf_routing.phpcr_route_provider"/>
+
         <service id="cmf_routing.phpcr_candidates_prefix" class="%cmf_routing.phpcr_candidates_prefix.class%">
             <argument>%cmf_routing.dynamic.persistence.phpcr.route_basepaths%</argument>
             <argument>%cmf_routing.dynamic.locales%</argument>
@@ -34,6 +36,8 @@
             <argument type="service" id="doctrine_phpcr"/>
             <call method="setManagerName"><argument>%cmf_routing.dynamic.persistence.phpcr.manager_name%</argument></call>
         </service>
+
+        <service id="cmf_routing.content_repository" alias="cmf_routing.phpcr_content_repository"/>
 
         <service id="cmf_routing.phpcrodm_route_idprefix_listener" class="%cmf_routing.phpcrodm_route_idprefix_listener.class%">
             <argument type="service" id="cmf_routing.phpcr_candidates_prefix"/>

--- a/Tests/Resources/Fixtures/config/config.xml
+++ b/Tests/Resources/Fixtures/config/config.xml
@@ -23,11 +23,11 @@
 
             <persistence>
                 <phpcr
-                    route-basepath="/cms/routes"
                     content-basepath="/cms/content"
                     use-sonata-admin="false"
                     enable-initializer="true"
                 >
+                    <route-basepath>/cms/routes</route-basepath>
                     <route-basepath>/simple</route-basepath>
                 </phpcr>
             </persistence>


### PR DESCRIPTION
Reasoning
---

The DI extension was very big and hard to follow. It's still pretty big, but I tried to simplify it a bit by moving some validation to the Configuration and splitting the handling in some methods.

Changes included in this PR
---

 * Made all methods in the extension class private instead of public (except from `load()`). These methods shouldn't be overriden and I don't think this is a BC break as nobody will ever override a DI extension (or they must do something very hacky).
 * Changed all `$this->getAlias()` calls to just `"cmf_routing"`. I don't see any advantage of calling this method: The `cmf_routing` prefix is already hardcoded in the service configuration files and many other places. To me, it only adds many method calls and some confusion (especially when used inside a `setAlias()` call of a service definition).
 * Split building the config tree in multiple methods, making it easier to follow what's going on.
 * Fixed the deprecation trigger of `route_basepath` when using XML.

Info
---

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -