### PR TITLE
Trigger deprecation notices

### DIFF
--- a/Doctrine/Phpcr/RedirectRoute.php
+++ b/Doctrine/Phpcr/RedirectRoute.php
@@ -73,9 +73,9 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      */
     public function setParent($parent)
     {
-        $this->parent = $parent;
+        @trigger_error('The Route#setParent() method is deprecated as of version 1.2 and will be removed in 2.0. Use setParentDocument() instead.', E_USER_DEPRECATED);
 
-        return $this;
+        return $this->setParentDocument($parent);
     }
 
     /**
@@ -83,7 +83,9 @@ class RedirectRoute extends RedirectRouteModel implements PrefixInterface, Hiera
      */
     public function getParent()
     {
-        return $this->parent;
+        @trigger_error('The Route#getParent() method is deprecated as of version 1.2 and will be removed in 2.0. Use getParentDocument() instead.', E_USER_DEPRECATED);
+
+        return $this->getParentDocument();
     }
 
     /**

--- a/Doctrine/Phpcr/Route.php
+++ b/Doctrine/Phpcr/Route.php
@@ -93,9 +93,9 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      */
     public function setParent($parent)
     {
-        $this->parent = $parent;
+        @trigger_error('The Route#setParent() method is deprecated as of version 1.2 and will be removed in 2.0. Use setParentDocument() instead.', E_USER_DEPRECATED);
 
-        return $this;
+        return $this->setParentDocument($parent);
     }
 
     /**
@@ -103,7 +103,9 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      */
     public function getParent()
     {
-        return $this->parent;
+        @trigger_error('The Route#getParent() method is deprecated as of version 1.2 and will be removed in 2.0. Use getParentDocument() instead.', E_USER_DEPRECATED);
+
+        return $this->getParentDocument();
     }
 
     /**
@@ -112,6 +114,8 @@ class Route extends RouteModel implements PrefixInterface, HierarchyInterface
      * Note that this will change the URL this route matches.
      *
      * @param object $parent the new parent document
+     *
+     * @return $this
      */
     public function setParentDocument($parent)
     {

--- a/Tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
+++ b/Tests/Functional/Doctrine/Phpcr/RouteProviderTest.php
@@ -45,7 +45,7 @@ class RouteProviderTest extends BaseTestCase
 
         // smuggle a non-route thing into the repository
         $noroute = new Generic;
-        $noroute->setParent($route);
+        $noroute->setParentDocument($route);
         $noroute->setNodename('noroute');
         $this->getDm()->persist($noroute);
 

--- a/Tests/Resources/DataFixtures/Phpcr/LoadRouteData.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadRouteData.php
@@ -26,7 +26,7 @@ class LoadRouteData implements FixtureInterface
 
         $root = $manager->find(null, '/test');
         $parent = new Generic;
-        $parent->setParent($root);
+        $parent->setParentDocument($root);
         $parent->setNodename('routing');
         $manager->persist($parent);
 


### PR DESCRIPTION
Symfony does now have really nice tools and a good handling of deprecation notices. So we should trigger deprecation notices whenever we deprecate anything.

Besides that, this 1.x release is probably one of the last releases in the 1 major so it also makes sense to warn users about deprecated features.

/cc @lsmith77 @dbu @dantleech 