### PR TITLE
Symfony3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache/files
- 
+
 env:
   global:
     - SYMFONY_DEPRECATIONS_HELPER=322
@@ -21,11 +21,9 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DEPS=dev
+      env: DEPS=dev SYMFONY_VERSION=2.8.*
     - php: 5.3
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-      env: SYMFONY_VERSION=2.3.*
+      env: COMPOSER_FLAGS="--prefer-lowest" SYMFONY_VERSION=2.7.*
     - php: 5.6
       env: SYMFONY_VERSION=2.7.*
   fast_finish: true
@@ -36,7 +34,7 @@ before_install:
   - composer self-update
   - if [ "$DEPS" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require symfony/symfony:${SYMFONY_VERSION} --no-update; fi
-  
+
 install: composer update --prefer-dist $COMPOSER_FLAGS
 
 before_script: vendor/symfony-cmf/testing/bin/travis/phpcr_odm_doctrine_dbal.sh

--- a/Admin/RedirectRouteAdmin.php
+++ b/Admin/RedirectRouteAdmin.php
@@ -40,7 +40,7 @@ class RedirectRouteAdmin extends Admin
     {
         $formMapper
             ->with('form.group_general')
-                ->add('parent', Sf2CompatUtil::getFormTypeName('doctrine_phpcr_odm_tree'), array('choice_list' => array(), 'select_root_node' => true, 'root_node' => $this->routeRoot))
+                ->add('parentDocument', Sf2CompatUtil::getFormTypeName('doctrine_phpcr_odm_tree'), array('choice_list' => array(), 'select_root_node' => true, 'root_node' => $this->routeRoot))
                 ->add('name', Sf2CompatUtil::getFormTypeName('text'))
                 ->add('routeName', Sf2CompatUtil::getFormTypeName('text'), array('required' => false))
                 ->add('uri', Sf2CompatUtil::getFormTypeName('text'), array('required' => false))

--- a/Admin/RouteAdmin.php
+++ b/Admin/RouteAdmin.php
@@ -66,7 +66,7 @@ class RouteAdmin extends Admin
                 'translation_domain' => 'CmfRoutingBundle',
             ))
                 ->add(
-                    'parent',
+                    'parentDocument',
                     Sf2CompatUtil::getFormTypeName('doctrine_phpcr_odm_tree'),
                     array('choice_list' => array(), 'select_root_node' => true, 'root_node' => $this->routeRoot)
                 )
@@ -146,7 +146,7 @@ class RouteAdmin extends Admin
             '_controller' => array('_controller', Sf2CompatUtil::getFormTypeName('text'), array('required' => false)),
             '_template' => array('_template', Sf2CompatUtil::getFormTypeName('text'), array('required' => false)),
             'type' => array('type', Sf2CompatUtil::getFormTypeName('cmf_routing_route_type'), array(
-                'empty_value' => '',
+                'placeholder' => '',
                 'required' => false,
             )),
         );

--- a/Model/Route.php
+++ b/Model/Route.php
@@ -181,7 +181,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
             return 'Symfony\\Component\\Routing\\RouteCompiler';
         }
         if ($this->isBooleanOption($name)) {
-            return (boolean) $option;
+            return (bool) $option;
         }
 
         return $option;
@@ -202,7 +202,7 @@ class Route extends SymfonyRoute implements RouteObjectInterface
         }
         foreach ($options as $key => $value) {
             if ($this->isBooleanOption($key)) {
-                $options[$key] = (boolean) $value;
+                $options[$key] = (bool) $value;
             }
         }
 

--- a/Tests/Resources/app/config/cmf_routing.phpcr.yml
+++ b/Tests/Resources/app/config/cmf_routing.phpcr.yml
@@ -3,4 +3,4 @@ cmf_routing:
         persistence:
             phpcr:
                 enabled: true
-                route_basepath: /test/routing
+                route_basepaths: /test/routing

--- a/Tests/Unit/Routing/DynamicRouterTest.php
+++ b/Tests/Unit/Routing/DynamicRouterTest.php
@@ -58,6 +58,9 @@ class DynamicRouterTest extends CmfUnitTestCase
         $this->assertEquals('template', $request->attributes->get(DynamicRouter::CONTENT_TEMPLATE));
     }
 
+    /**
+     * @group legacy
+     */
     public function testMatch()
     {
         $this->eventDispatcher->expects($this->once())
@@ -86,6 +89,8 @@ class DynamicRouterTest extends CmfUnitTestCase
 
     /**
      * @expectedException \Symfony\Component\Routing\Exception\ResourceNotFoundException
+     *
+     * @group legacy
      */
     public function testMatchNoRequest()
     {

--- a/Tests/WebTest/RedirectRouteAdminTest.php
+++ b/Tests/WebTest/RedirectRouteAdminTest.php
@@ -64,7 +64,7 @@ class RedirectRouteAdminTest extends BaseTestCase
         $actionUrl = $node->getAttribute('action');
         $uniqId = substr(strstr($actionUrl, '='), 1);
 
-        $form[$uniqId.'[parent]'] = '/test/routing';
+        $form[$uniqId.'[parentDocument]'] = '/test/routing';
         $form[$uniqId.'[name]'] = 'foo-test';
 
         $this->client->submit($form);

--- a/Tests/WebTest/RouteAdminTest.php
+++ b/Tests/WebTest/RouteAdminTest.php
@@ -64,7 +64,7 @@ class RouteAdminTest extends BaseTestCase
         $actionUrl = $node->getAttribute('action');
         $uniqId = substr(strstr($actionUrl, '='), 1);
 
-        $form[$uniqId.'[parent]'] = '/test/routing';
+        $form[$uniqId.'[parentDocument]'] = '/test/routing';
         $form[$uniqId.'[name]'] = 'foo-test';
 
         $this->client->submit($form);

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.3.9|^7.0",
         "symfony-cmf/routing": "~1.2",
-        "symfony/framework-bundle": "~2.3"
+        "symfony/framework-bundle": "~2.7|~3.0"
     },
     "require-dev": {
         "symfony-cmf/core-bundle": "~1.1",
@@ -23,7 +23,10 @@
         "matthiasnoback/symfony-dependency-injection-test": "~0.6",
         "matthiasnoback/symfony-config-test": "^1.3.1",
         "phpunit/php-code-coverage": "@stable",
-        "sonata-project/doctrine-phpcr-admin-bundle": "^1.1",
+        "sonata-project/admin-bundle": "^2.2.12",
+        "sonata-project/core-bundle": "^2.2.3",
+        "sonata-project/block-bundle": "^2.2.8",
+        "sonata-project/doctrine-phpcr-admin-bundle": "^1.2.3",
         "symfony/monolog-bundle": "~2.3",
         "doctrine/orm": "~2.3",
         "doctrine/data-fixtures": "^1.0.0-alpha3"


### PR DESCRIPTION
- allow Symfony ~3.0
- bump Symfony dependency to ~2.7
- specify correct Sonata dependencies
- use parentDocument in Admin classes
- update route_basepaths in tests
- make StyleCI happy

See #331