### PR TITLE
do not fail on non-default naming strategies for the 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+* **2016-01-09**: [ORM] Hardcoded some column names to match what we index on to avoid
+  issues with non-default `orm.naming_strategy`. It is now safe to use a non-default
+  naming strategy. If you did a workaround to use a naming strategy, you might need to
+  look into that.
+* **2015-10-28**: Deprecated `cmf_routing.dynamic.persistence.phpcr.route_basepath`
+  setting and parameter in favor of `cmf_routing.dynamic.persistence.phpcr.route_basepaths`.
+  The old names will be kept for BC reasons and removed in 2.0.
+
+1.3.0
+-----
+
 1.3.0-RC1
 ---------
 

--- a/Resources/config/doctrine-model/Route.orm.xml
+++ b/Resources/config/doctrine-model/Route.orm.xml
@@ -4,10 +4,10 @@
 
     <mapped-superclass name="Symfony\Cmf\Bundle\RoutingBundle\Model\Route">
         <field name="variablePattern" type="string" nullable="true"/>
-        <field name="staticPrefix" type="string" nullable="true"/>
+        <!-- we hardcode the column name to overwrite column naming strategies as we have to define the index on the column name -->
+        <field name="staticPrefix" type="string" nullable="true" column="staticPrefix"/>
 
         <indexes>
-            <index name="name_idx" columns="name"/>
             <index name="prefix_idx" columns="staticPrefix"/>
         </indexes>
     </mapped-superclass>

--- a/Resources/config/doctrine-orm/Route.orm.xml
+++ b/Resources/config/doctrine-orm/Route.orm.xml
@@ -8,8 +8,13 @@
             <generator strategy="AUTO"/>
         </id>
 
-        <field name="name" type="string" unique="true"/>
+        <!-- we hardcode the column name to overwrite column naming strategies as we have to define the index on the column name -->
+        <field name="name" type="string" unique="true" column="name"/>
         <field name="position" type="integer"/>
+
+        <indexes>
+            <index name="name_idx" columns="name"/>
+        </indexes>
 
     </entity>
 


### PR DESCRIPTION
error
``` bash
 [Doctrine\DBAL\Schema\SchemaException]                              
  There is no column with name 'staticPrefix' on table 'orm_routes'. 
```
[do not fail on non-default naming strategies](https://github.com/symfony-cmf/RoutingBundle/pull/330)