### PR TITLE
use tag dynamic_router_route_enhancer for the all enhancer

### DIFF
--- a/DependencyInjection/CmfRoutingExtension.php
+++ b/DependencyInjection/CmfRoutingExtension.php
@@ -145,15 +145,18 @@ class CmfRoutingExtension extends Extension
 
         // if any mappings are defined, set the respective route enhancer
         if (count($config['controllers_by_type']) > 0) {
-            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.controllers_by_type'), 60));
+            $container->getDefinition('cmf_routing.enhancer.controllers_by_type')
+                ->addTag('dynamic_router_route_enhancer', array('priority' => 60));
         }
 
         if (count($config['controllers_by_class']) > 0) {
-            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.controllers_by_class'), 50));
+            $container->getDefinition('cmf_routing.enhancer.controllers_by_class')
+                      ->addTag('dynamic_router_route_enhancer', array('priority' => 50));
         }
 
         if (count($config['templates_by_class']) > 0) {
-            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.templates_by_class'), 40));
+            $container->getDefinition('cmf_routing.enhancer.templates_by_class')
+                      ->addTag('dynamic_router_route_enhancer', array('priority' => 40));
 
             /*
              * The CoreBundle prepends the controller from ContentBundle if the
@@ -176,15 +179,18 @@ class CmfRoutingExtension extends Extension
             $definition = $container->getDefinition('cmf_routing.enhancer.controller_for_templates_by_class');
             $definition->replaceArgument(2, $controllerForTemplates);
 
-            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.controller_for_templates_by_class'), 30));
+            $container->getDefinition('cmf_routing.enhancer.controller_for_templates_by_class')
+                      ->addTag('dynamic_router_route_enhancer', array('priority' => 30));
         }
 
         if (null !== $config['generic_controller'] && $defaultController !== $config['generic_controller']) {
-            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.explicit_template'), 10));
+            $container->getDefinition('cmf_routing.enhancer.explicit_template')
+                      ->addTag('dynamic_router_route_enhancer', array('priority' => 10));
         }
 
         if (null !== $defaultController) {
-            $dynamic->addMethodCall('addRouteEnhancer', array(new Reference('cmf_routing.enhancer.default_controller'), -100));
+            $container->getDefinition('cmf_routing.enhancer.default_controller')
+                      ->addTag('dynamic_router_route_enhancer', array('priority' => -100));
         }
 
         if (count($config['route_filters_by_id']) > 0) {

--- a/Resources/config/routing-dynamic.xml
+++ b/Resources/config/routing-dynamic.xml
@@ -23,6 +23,7 @@
         <service id="cmf_routing.enhancer.route_content" class="%cmf_routing.enhancer.route_content.class%">
             <argument>_route_object</argument>
             <argument>_content</argument>
+            <tag name="dynamic_router_route_enhancer" priority="100"/>
         </service>
 
         <service id="cmf_routing.enhancer.default_controller" class="%cmf_routing.enhancer.default_controller.class%" public="false">
@@ -69,10 +70,6 @@
             <argument type="service" id="event_dispatcher" on-invalid="ignore"/>
             <argument type="service" id="cmf_routing.route_provider"/>
             <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false"/></call>
-            <call method="addRouteEnhancer">
-                <argument type="service" id="cmf_routing.enhancer.route_content"/>
-                <argument>100</argument>
-            </call>
         </service>
 
         <service id="cmf_routing.nested_matcher" class="%cmf_routing.nested_matcher.class%">

--- a/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/CmfRoutingExtensionTest.php
@@ -48,6 +48,11 @@ class CmfRoutingExtensionTest extends AbstractExtensionTestCase
             new Reference('router.default'),
             100,
         ));
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'cmf_routing.enhancer.route_content',
+            'dynamic_router_route_enhancer',
+            array('priority' => 100)
+        );
     }
 
     public function testLoadConfigured()
@@ -113,6 +118,12 @@ class CmfRoutingExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('cmf_routing.controllers_by_type', array(
             'Acme\Foo' => 'acme_main.controller:indexAction',
         ));
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            'cmf_routing.enhancer.controllers_by_type',
+            'dynamic_router_route_enhancer',
+            array('priority' => 60)
+        );
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | [no]
| New feature?  | [no]
| BC breaks?    | [no]
| Deprecations? | [no]
| Tests pass?   | [yes]
| Fixed tickets | []
| License       | MIT
| Doc PR        | []

use docs [Writing your own Route Enhancers](http://symfony.com/doc/master/cmf/bundles/routing/dynamic_customize.html#writing-your-own-route-enhancers) for the create internal Enhancers, I think it's more clearer.
what do you think?