### PR TITLE
Check Metadata Class info exists

### DIFF
--- a/Doctrine/RouteConditionMetadataListener.php
+++ b/Doctrine/RouteConditionMetadataListener.php
@@ -49,6 +49,11 @@ class RouteConditionMetadataListener implements EventSubscriber
         }
 
         $meta = $eventArgs->getClassMetadata();
+
+        if (null === $meta->getReflectionClass()) {
+            return;
+        }
+
         if ($meta->getReflectionClass()->getName() !== 'Symfony\Component\Routing\Route') {
             return;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT


Sometimes, Metadata ReflectionClass is null and throws:

PHP Fatal error:  Call to a member function getName() on a non-object in vendor/symfony-cmf/routing-bundle/Doctrine/RouteConditionMetadataListener.php on line 52

i.e. I get this error when I try to use doctrine:generate:entities command using orm persistence.