### PR TITLE
Use content locale for frontend link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DEPS=dev
+      env: SYMFONY_VERSION=2.8.* DEPS=dev
     - php: 5.3
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.6

--- a/Admin/Extension/FrontendLinkExtension.php
+++ b/Admin/Extension/FrontendLinkExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Cmf\Bundle\RoutingBundle\Admin\Extension;
 use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Admin\AdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Cmf\Bundle\CoreBundle\Translatable\TranslatableInterface;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\PrefixInterface;
 use Symfony\Cmf\Component\Routing\RouteReferrersReadInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -75,7 +76,7 @@ class FrontendLinkExtension extends AdminExtension
         if (!$subject instanceof RouteReferrersReadInterface && !$subject instanceof Route) {
             throw new InvalidConfigurationException(
                 sprintf(
-                    '%s can only be used on subjects which implement Symfony\Cmf\Component\Routing\RouteReferrersReadInterface or Symfony\Component\Routing\Route!',
+                    '%s can only be used on subjects which implement Symfony\Cmf\Component\Routing\RouteReferrersReadInterface or Symfony\Component\Routing\Route.',
                     __CLASS__
                 )
             );
@@ -86,8 +87,15 @@ class FrontendLinkExtension extends AdminExtension
             return;
         }
 
+        $defaults = array();
+        if ($subject instanceof TranslatableInterface) {
+            if ($locale = $subject->getLocale()) {
+                $defaults['_locale'] = $locale;
+            }
+        }
+
         try {
-            $uri = $this->router->generate($subject);
+            $uri = $this->router->generate($subject, $defaults);
         } catch (RoutingExceptionInterface $e) {
             // we have no valid route
             return;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | -
| License       | MIT
| Doc PR        | -

When using SonataTranslationBundle, if we edit the `de` content, I want to go to the de content when clicking the "front-end link" button. However, at the moment, the locale of the admin panel is used instead of the edited content. This PR changes/fixes that

